### PR TITLE
Fixed typo to improve security

### DIFF
--- a/login.php
+++ b/login.php
@@ -14,7 +14,7 @@ if (!$userid)
     goback("Wrong username or password");
 $realpassword = $r->hget("user:$userid","password");
 if ($realpassword != $password)
-    goback("Wrong useranme or password");
+    goback("Wrong username or password");
 
 # Username / password OK, set the cookie and redirect to index.php
 $authsecret = $r->hget("user:$userid","auth");


### PR DESCRIPTION
The typo caused the user to be able to distinguish if the password was incorrect vs. if the username was incorrect, which is potentially a minor security hole.